### PR TITLE
Update fleet to support clojure 1.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,8 @@
 (defproject
-  fleet "0.9.4"
+  metajack/fleet "0.9.5-SNAPSHOT"
   :description "Templating System for Clojure"
   :url "http://github.com/Flamefork/fleet"
 
-  :dependencies [[org.clojure/clojure "1.1.0"]
-                 [org.clojure/clojure-contrib "1.1.0"]]
+  :dependencies [[org.clojure/clojure "1.3.0"]]
   :java-source-path "src"
-  :dev-dependencies [[lein-clojars "0.6.0"]])
+  :dev-dependencies [[lein-clojars "0.7.0"]])

--- a/src/fleet/builder.clj
+++ b/src/fleet/builder.clj
@@ -1,6 +1,6 @@
 (ns fleet.builder
   (:require
-    [clojure.contrib.str-utils2 :as su])
+    [clojure.string :as str])
   (:use
     [fleet runtime util]))
 
@@ -23,6 +23,6 @@
   "Build Clojure forms from template-str."
   [args ast]
   (str
-    "(fn [runtime " (su/join " " args) "] "
+    "(fn [runtime " (str/join " " args) "] "
     "(let [{:keys [raw raw? screen]} runtime] "
     (consume ast) "))"))

--- a/src/fleet/loader.clj
+++ b/src/fleet/loader.clj
@@ -2,7 +2,7 @@
   (:import
     java.io.File)
   (:require
-    [clojure.contrib.str-utils2 :as su]))
+    [clojure.string :as str]))
 
 (defn- ns-from-path
   [path]
@@ -14,8 +14,8 @@
 (defn- names-from-filename
   "Make (post-html-fleet post-html post) from 'post.html.fleet'"
   [filename]
-  (map #(ns-from-path (su/join \. %))
-    (loop [s (su/split filename #"\.")
+  (map #(ns-from-path (str/join \. %))
+    (loop [s (str/split filename #"\.")
            names []]
       (if (nil? s)
         names


### PR DESCRIPTION
The changes are simple as clojure.contrib.str-utils2 is now in clojure.string. Unfortunately, this will be a backwards incompatible change.
